### PR TITLE
fix: remove react query devtools

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,7 +5,6 @@ import { checkAuth } from './redux/slices/authSlice';
 import Entry from './Entry';
 import { fetchProfile } from './redux/slices/profileSlice ';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const queryClient = new QueryClient();
 
@@ -13,7 +12,6 @@ const AppWrapper = () => (
   <Provider store={store}>
     <QueryClientProvider client={queryClient}>
       <App />
-      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </Provider>
 );


### PR DESCRIPTION
This commit removes the `@tanstack/react-query-devtools` from the application as they are not compatible with React Native.